### PR TITLE
Set version constraint for IQKeyboardManager pod

### DIFF
--- a/platforms/ios/Podfile
+++ b/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'IQKeyboardManager'
+pod 'IQKeyboardManager', '~> 4.0.0'


### PR DESCRIPTION
We want all versions up to but not including 5.0. This means the user won't be inadvertently upgraded to a version with a breaking change. Closes #2.