### PR TITLE
Update Podfile to IQKeyboardManager 6.0.0

### DIFF
--- a/src/platforms/ios/Podfile
+++ b/src/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'IQKeyboardManager', '~> 5.0.0'
+pod 'IQKeyboardManager', '~> 6.0.0'


### PR DESCRIPTION
Can we upgrade the Podfile to use IQKeyboardManager 6.0.0? v5 doesn't work well on the latest version of iOS, and v6 seems to work fine.