### PR TITLE
Readme documentation for iOS oneTimeCode textContentType.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,35 @@ iqKeyboard.keyboardAppearance = UIKeyboardAppearance.Dark;
 
 For more examples of what's possible, run the demo app (shown in the gif below) and check out the [app's `main-view-model.ts` file](demo/app/main-view-model.ts).
 
-<img src="https://github.com/tjvantoll/nativescript-IQKeyboardManager/raw/master/demo.gif" width="320px"/> 
+<img src="https://github.com/tjvantoll/nativescript-IQKeyboardManager/raw/master/demo.gif" width="320px"/>
+
+### Multi-factor one time code auto-fill
+
+While the following is not a feature specific to IQKeyboardManager, you are here because you want the best keyboard experience for your NativeScript app and this may be helpful to know about.
+
+iOS has a feature where a text field's QuickType search suggestion bar can suggest one time code values for multi-factor authentication that were texted to your device.
+
+If the field is specially-identified as a one time code field, the suggestion will appear for about 3 minutes after being received and the user simply has to tap the suggestion to fill in the value. No short term memorization or copy/paste gestures required. Examples of message formats are:
+* 123456 is your App Name code.
+* 123456 is your App Name login code.
+* 123456 is your App Name verification code.
+
+In Angular, first declare `UITextContentTypeOneTimeCode` near your component imports:
+
+```typescript
+declare var UITextContentTypeOneTimeCode;
+```
+
+Then, set field's `ios.textContentType`:
+
+```typescript
+const mfaCodeField: TextField = this.page.getViewById(oneTimeCodeFieldName);
+if (mfaCodeField !== null && mfaCodeField.ios) {
+  mfaCodeField.ios.textContentType = UITextContentTypeOneTimeCode;
+}
+```
+
+There are other textContentType values too, see more in [this article](https://medium.com/developerinsider/ios12-password-autofill-automatic-strong-password-and-security-code-autofill-6e7db8da1810).
 
 ## Documentation
 


### PR DESCRIPTION
Readme changes discussed at https://www.nativescript.org/blog/building-an-awesome-login-screen-with-nativescript