### PR TITLE
Bump IQKeyboardManager Pod to 6.2.0, and NativeScript to 5.1.x

### DIFF
--- a/demo/app/app.ts
+++ b/demo/app/app.ts
@@ -1,2 +1,3 @@
 import * as application from "tns-core-modules/application";
-application.start({ moduleName: "main-page" });
+
+application.run({moduleName: "main-page"});

--- a/demo/app/main-page.xml
+++ b/demo/app/main-page.xml
@@ -1,4 +1,5 @@
 <Page xmlns="http://schemas.nativescript.org/tns.xsd" xmlns:IQKeyboardManager="nativescript-iqkeyboardmanager" loaded="pageLoaded">
+  <ActionBar title="IQKeyboard Manager demo"/>
   <ScrollView>
     <StackLayout>
 

--- a/demo/package.json
+++ b/demo/package.json
@@ -2,23 +2,23 @@
   "nativescript": {
     "id": "org.nativescript.iqkeyboardmanagerdemo",
     "tns-ios": {
-      "version": "3.4.0"
+      "version": "5.1.0"
     },
     "tns-android": {
-      "version": "3.4.1"
+      "version": "5.1.0"
     }
   },
   "dependencies": {
     "nativescript-iqkeyboardmanager": "../src",
-    "tns-core-modules": "~3.4.0"
+    "tns-core-modules": "~5.1.2"
   },
   "devDependencies": {
     "babel-traverse": "6.26.0",
     "babel-types": "6.26.0",
     "babylon": "6.18.0",
     "lazy": "1.0.11",
-    "nativescript-dev-typescript": "^0.6.0",
-    "tns-platform-declarations": "~3.4.1",
-    "typescript": "~2.6.0"
+    "nativescript-dev-typescript": "~0.7.9",
+    "tns-platform-declarations": "~5.1.2",
+    "typescript": "~3.1.0"
   }
 }

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -25,7 +25,17 @@
             "./node_modules/@types",
             "./node_modules"
         ],
-        "types": []
+        "types": [],
+        "baseUrl": ".",
+        "paths": {
+            "*": [
+                "./node_modules/tns-core-modules/*",
+                "./node_modules/*"
+            ],
+            "~/*": [
+                "app/*"
+            ]
+        }
     },
     "exclude": [
         "node_modules",

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-iqkeyboardmanager",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "NativeScript wrapper of the popular IQKeyboardManager iOS library",
   "main": "iqkeyboardmanager",
   "typings": "index.d.ts",
@@ -12,9 +12,9 @@
   },
   "scripts": {
     "build": "npm i && tsc",
-    "demo.ios": "cd ../demo && tns run ios --emulator --syncAllFiles",
-    "demo.ios.device": "cd ../demo && tns run ios --syncAllFiles",
-    "demo.android": "cd ../demo && tns run android --syncAllFiles",
+    "demo.ios": "npm run build && cd ../demo && tns run ios --emulator --syncAllFiles",
+    "demo.ios.device": "npm run build && cd ../demo && tns run ios --syncAllFiles",
+    "demo.android": "npm run build && cd ../demo && tns run android --syncAllFiles",
     "setup": "npm run build && cd ../demo && npm i",
     "setupandinstall": "npm i && cd ../demo && npm i && cd ../src && npm run build && cd ../demo && tns plugin add ../src && cd ../src",
     "tslint": "tslint --config '../tslint.json' '*.ts' --exclude '**/node_modules/**'",
@@ -43,10 +43,10 @@
     "url": "https://github.com/tjvantoll/nativescript-IQKeyboardManager/issues"
   },
   "devDependencies": {
-    "nativescript-dev-typescript": "^0.6.0",
-    "tns-core-modules": "~3.4.0",
-    "tns-platform-declarations": "~3.4.0",
-    "typescript": "~2.6.0",
+    "nativescript-dev-typescript": "~0.7.9",
+    "tns-core-modules": "~5.1.2",
+    "tns-platform-declarations": "~5.1.2",
+    "typescript": "~3.1.0",
     "tslint": "^5.0.0"
   }
 }

--- a/src/platforms/ios/Podfile
+++ b/src/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'IQKeyboardManager', '~> 6.0.0'
+pod 'IQKeyboardManager', '~> 6.2.0'


### PR DESCRIPTION
Tested with the embedded demo app.