### PR TITLE
Update Pod to newer version 6.5.3

### DIFF
--- a/src/platforms/ios/Podfile
+++ b/src/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'IQKeyboardManager', '~> 6.2.0'
+pod 'IQKeyboardManager', '~> 6.5'


### PR DESCRIPTION
Update to last version of the IQKeyboardManager Pod (6.5.3), and change the version number to automatically update the dependency up to MINOR changes and not MAJOR.

If update only to PATCH version is intended, justy modify podfile to new version: `pod 'IQKeyboardManager', '~> 6.5.3'`